### PR TITLE
Update create compatibility for create >= 6.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,13 +96,20 @@ repositories {
     maven {
         url "https://maven.jaackson.me"
     }
+    maven {
+        // location of ponder, library used by create
+        name = "Create Mod Maven"
+        url = "https://maven.createmod.net"
+    }
 }
 
 dependencies {
     minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}"
 
     //Compat
-    compileOnly fg.deobf("curse.maven:create-328085:5838779")
+    compileOnly fg.deobf("com.simibubi.create:create-${mc_version}:${create_version}")
+    // library used by create
+    compileOnly(fg.deobf("net.createmod.ponder:Ponder-Forge-${mc_version}:${ponder_version}"))
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,7 @@ org.gradle.daemon=false
 mc_version=1.20.1
 forge_version=47.3.22
 mod_version=1.1.0
+
+# Compat
+create_version = 6.0.1-25:all
+ponder_version=1.0.43

--- a/src/main/java/io/github/ManaStar/poscendo/core/mixin/CreatePotionFluidTypeMixin.java
+++ b/src/main/java/io/github/ManaStar/poscendo/core/mixin/CreatePotionFluidTypeMixin.java
@@ -3,7 +3,7 @@ package io.github.ManaStar.poscendo.core.mixin;
 import com.simibubi.create.AllFluids;
 import com.simibubi.create.content.fluids.potion.PotionFluid;
 import com.simibubi.create.content.fluids.potion.PotionFluidHandler;
-import com.simibubi.create.foundation.utility.NBTHelper;
+import net.createmod.catnip.nbt.NBTHelper;
 import io.github.ManaStar.poscendo.core.PoscendoConfig;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -27,3 +27,9 @@ mandatory = true
 versionRange = "[1.20.1,1.21)"
 ordering = "NONE"
 side = "BOTH"
+[[dependencies.poscendo]]
+modId = "create"
+mandatory = false
+versionRange = "[6.0.0,)"
+ordering = "AFTER"
+side = "BOTH"


### PR DESCRIPTION
  - Added create + ponder as compile dependencies in build.gradle with appropriate versions using create's new maven.
    - CreatePotionFluidTypeMixin.java simply had to change the NBTHelper to point to create's new class as it has been moved to the separate ponder mod.
  - Added create as a formal optional dependency in mods.toml